### PR TITLE
return the old client

### DIFF
--- a/singlebeat/beat.py
+++ b/singlebeat/beat.py
@@ -92,8 +92,7 @@ class Config(object):
             host=host,
             port=port,
             password=password)
-        r = aioredis.Redis(redis_connection)
-        return r.pubsub()
+        return aioredis.Redis(redis_connection)
 
     def get_host_identifier(self):
         """\


### PR DESCRIPTION
Now that we downgraded from aioredis 2.0 to 1.3.1, use the old client